### PR TITLE
chore: 🔧 Update .gitignore, add log files pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 
 .wwebjs_cache
 .wwebjs_auth
+
+*.log

--- a/Formula/wa-tui.rb
+++ b/Formula/wa-tui.rb
@@ -1,14 +1,14 @@
 class WaTui < Formula
   desc "Terminal UI for WhatsApp Web"
   homepage "https://github.com/gtchakama/wa-tui"
-  url "https://registry.npmjs.org/@gtchakama/wa-tui/-/wa-tui-1.4.0.tgz"
-  sha256 "fa475b510dccc60dae1588def04ee6d1f3625e2d0d7df62a38f82c20944f2a94"
+  url "https://registry.npmjs.org/@gtchakama/wa-tui/-/wa-tui-1.4.4.tgz"
+  sha256 "7a0b665178511f0a75fea20bf2ab9c093b1119fc727fc47258f942eec446f46c"
   license "ISC"
 
   depends_on "node"
 
   def install
-    system "npm", "install", *std_npm_install_args(libexec)
+    system "npm", "install", *std_npm_args
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Session data and cache are stored under `.wwebjs_auth` and `.wwebjs_cache` in th
 
 ### Homebrew (macOS / Linux)
 
-Uses [Homebrew](https://brew.sh/) so `wa-tui` is on your PATH like any other CLI. This repository is a [tap](https://docs.brew.sh/Taps): it contains [`Formula/wa-tui.rb`](Formula/wa-tui.rb), which installs the published npm tarball and pulls in **Node** as a dependency.
+Uses [Homebrew](https://brew.sh/) so `wa-tui` is on your PATH like any other CLI. This repository contains [`Formula/wa-tui.rb`](Formula/wa-tui.rb), which installs the published npm tarball and pulls in **Node** as a dependency. Because the GitHub repository is named `wa-tui` rather than `homebrew-wa-tui`, tap it with an explicit URL:
 
 ```bash
-brew tap gtchakama/wa-tui
-brew install wa-tui
+brew tap gtchakama/wa-tui https://github.com/gtchakama/wa-tui
+brew install gtchakama/wa-tui/wa-tui
 ```
 
 Upgrade later with `brew upgrade wa-tui`. You still need **Chrome** or **Chromium** locally (see Requirements).


### PR DESCRIPTION
build: 📦 Bump wa-tui version to 1.4.4
docs: 📚 Update Homebrew tap instructions
fix: 🐛 patch Formula to use `std_npm_args` instead of `std_npm_install_args` the old API